### PR TITLE
use new arith api

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -805,8 +805,8 @@ checksum = "cc9c68a3f6da06753e9335d63e27f6b9754dd1920d941135b7ea8224f141adb2"
 
 [[package]]
 name = "powdr-riscv-runtime"
-version = "0.1.0-alpha.2"
-source = "git+https://github.com/powdr-labs/powdr.git?tag=v0.1.1#699b74ac5b032113270a2f419ef192bdb7fc0857"
+version = "0.1.3"
+source = "git+https://github.com/powdr-labs/powdr.git?branch=main#4f1aa4a5f3879e974f8f668b728a8f7eb656b528"
 dependencies = [
  "getrandom",
  "powdr-riscv-syscalls",
@@ -816,8 +816,8 @@ dependencies = [
 
 [[package]]
 name = "powdr-riscv-syscalls"
-version = "0.1.1"
-source = "git+https://github.com/powdr-labs/powdr.git?tag=v0.1.1#699b74ac5b032113270a2f419ef192bdb7fc0857"
+version = "0.1.3"
+source = "git+https://github.com/powdr-labs/powdr.git?branch=main#4f1aa4a5f3879e974f8f668b728a8f7eb656b528"
 
 [[package]]
 name = "ppv-lite86"

--- a/k256/Cargo.toml
+++ b/k256/Cargo.toml
@@ -35,7 +35,7 @@ sha2 = { version = "=0.11.0-pre.4", optional = true, default-features = false }
 signature = { version = "=2.3.0-pre.4", optional = true }
 
 [target.'cfg(all(target_os = "zkvm", target_arch = "riscv32"))'.dependencies]
-powdr-riscv-runtime = { git = "https://github.com/powdr-labs/powdr.git", tag = "v0.1.1", features = [
+powdr-riscv-runtime = { git = "https://github.com/powdr-labs/powdr.git", branch = "main", features = [
   "std",
   "getrandom",
   "allow_fake_rand",

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -123,9 +123,8 @@ impl FieldElement {
     }
 
     #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
-    pub fn as_bytes_le_mut(&self, out: &mut [u8; 32]) {
-        let bytes = self.0.normalize().to_bytes_le();
-        out.copy_from_slice(&bytes);
+    pub fn write_bytes_le(&self, out: &mut [u8; 32]) {
+        self.0.normalize().write_bytes_le(out);
     }
 
     /// Convert a `i64` to a field element.

--- a/k256/src/arithmetic/field.rs
+++ b/k256/src/arithmetic/field.rs
@@ -122,6 +122,12 @@ impl FieldElement {
         self.0.normalize().to_bytes_le()
     }
 
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub fn as_bytes_le_mut(&self, out: &mut [u8; 32]) {
+        let bytes = self.0.normalize().to_bytes_le();
+        out.copy_from_slice(&bytes);
+    }
+
     /// Convert a `i64` to a field element.
     /// Returned value may be only weakly normalized.
     #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]

--- a/k256/src/arithmetic/field/field_8x32.rs
+++ b/k256/src/arithmetic/field/field_8x32.rs
@@ -83,6 +83,11 @@ impl FieldElement8x32 {
         self.0.to_le_byte_array()
     }
 
+    pub fn write_bytes_le(self, out: &mut [u8; 32]) {
+        let bytes = self.0.to_le_byte_array();
+        out.copy_from_slice(&bytes);
+    }
+
     /// Checks if the field element is greater or equal to the modulus.
     fn get_overflow(&self) -> Choice {
         let (_, carry) = self.0.adc(&MODULUS_CORRECTION, Limb(0));

--- a/k256/src/arithmetic/field/field_impl.rs
+++ b/k256/src/arithmetic/field/field_impl.rs
@@ -110,6 +110,12 @@ impl FieldElementImpl {
         self.value.to_bytes_le()
     }
 
+    #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
+    pub fn write_bytes_le(self, out: &mut [u8; 32]) {
+        debug_assert!(self.normalized);
+        self.value.write_bytes_le(out)
+    }
+
     pub fn normalize_weak(&self) -> Self {
         Self::new_weak_normalized(&self.value.normalize_weak())
     }

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -101,26 +101,36 @@ impl ProjectivePoint {
         {
             // call when the values are normalized, into powdr ec operations
             if self.z == FieldElement::ONE && other.z == FieldElement::ONE {
+                let mut combined_self: [u8; 64] = [0; 64];
+                let mut combined_other: [u8; 64] = [0; 64];
+
                 // z being ONE means value is not identity
-                let self_x: [u8; 32] = self.x.to_bytes_le().into();
-                let self_y: [u8; 32] = self.y.to_bytes_le().into();
-                let other_x: [u8; 32] = other.x.to_bytes_le().into();
-                let other_y: [u8; 32] = other.y.to_bytes_le().into();
+                self.x.as_bytes_le_mut(
+                    (&mut combined_self[..32])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+                self.y.as_bytes_le_mut(
+                    (&mut combined_self[32..])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
 
-                let mut combined: [u8; 64] = [0; 64];
-                let result = if self_x == other_x && self_y == other_y {
-                    combined[..32].copy_from_slice(&self_x);
-                    combined[32..].copy_from_slice(&self_y);
-                    double_u8_le(combined)
+                other.x.as_bytes_le_mut(
+                    (&mut combined_other[..32])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+                other.y.as_bytes_le_mut(
+                    (&mut combined_other[32..])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+
+                let result = if combined_self == combined_other {
+                    double_u8_le(combined_self)
                 } else {
-                    combined[..32].copy_from_slice(&self_x);
-                    combined[32..].copy_from_slice(&self_y);
-
-                    let mut combined_other: [u8; 64] = [0; 64];
-                    combined_other[..32].copy_from_slice(&other_x);
-                    combined_other[32..].copy_from_slice(&other_y);
-
-                    add_u8_le(combined, combined_other)
+                    add_u8_le(combined_self, combined_other)
                 };
                 let (res_x, res_y) = result.split_at(32);
 
@@ -218,27 +228,38 @@ impl ProjectivePoint {
             if other.is_identity().into() {
                 return *self;
             } else if self.z == FieldElement::ONE {
+                let mut combined_self: [u8; 64] = [0; 64];
+                let mut combined_other: [u8; 64] = [0; 64];
+
                 // z being ONE means value is not identity
-                let self_x: [u8; 32] = self.x.to_bytes_le().into();
-                let self_y: [u8; 32] = self.y.to_bytes_le().into();
-                let other_x: [u8; 32] = other.x.to_bytes_le().into();
-                let other_y: [u8; 32] = other.y.to_bytes_le().into();
+                self.x.as_bytes_le_mut(
+                    (&mut combined_self[..32])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+                self.y.as_bytes_le_mut(
+                    (&mut combined_self[32..])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
 
-                let mut combined: [u8; 64] = [0; 64];
-                let result = if self_x == other_x && self_y == other_y {
-                    combined[..32].copy_from_slice(&self_x);
-                    combined[32..].copy_from_slice(&self_y);
-                    double_u8_le(combined)
+                other.x.as_bytes_le_mut(
+                    (&mut combined_other[..32])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+                other.y.as_bytes_le_mut(
+                    (&mut combined_other[32..])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+
+                let result = if combined_self == combined_other {
+                    double_u8_le(combined_self)
                 } else {
-                    combined[..32].copy_from_slice(&self_x);
-                    combined[32..].copy_from_slice(&self_y);
-
-                    let mut combined_other: [u8; 64] = [0; 64];
-                    combined_other[..32].copy_from_slice(&other_x);
-                    combined_other[32..].copy_from_slice(&other_y);
-
-                    add_u8_le(combined, combined_other)
+                    add_u8_le(combined_self, combined_other)
                 };
+
                 let (res_x, res_y) = result.split_at(32);
 
                 let mut res = *self;
@@ -322,16 +343,21 @@ impl ProjectivePoint {
         #[cfg(all(target_os = "zkvm", target_arch = "riscv32"))]
         {
             if self.z == FieldElement::ONE {
-                // z being ONE means value is not identity
-                let self_x: [u8; 32] = self.x.to_bytes_le().into();
-                let self_y: [u8; 32] = self.y.to_bytes_le().into();
+                let mut combined_self: [u8; 64] = [0; 64];
 
-                let result = {
-                    let mut combined: [u8; 64] = [0; 64];
-                    combined[..32].copy_from_slice(&self_x);
-                    combined[32..].copy_from_slice(&self_y);
-                    double_u8_le(combined)
-                };
+                // z being ONE means value is not identity
+                self.x.as_bytes_le_mut(
+                    (&mut combined_self[..32])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+                self.y.as_bytes_le_mut(
+                    (&mut combined_self[32..])
+                        .try_into()
+                        .expect("Expected 32 bytes"),
+                );
+
+                let result = double_u8_le(combined_self);
                 let (res_x, res_y) = result.split_at(32);
 
                 let mut res = *self;

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -105,23 +105,23 @@ impl ProjectivePoint {
                 let mut combined_other: [u8; 64] = [0; 64];
 
                 // z being ONE means value is not identity
-                self.x.as_bytes_le_mut(
+                self.x.write_bytes_le(
                     (&mut combined_self[..32])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
-                self.y.as_bytes_le_mut(
+                self.y.write_bytes_le(
                     (&mut combined_self[32..])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
 
-                other.x.as_bytes_le_mut(
+                other.x.write_bytes_le(
                     (&mut combined_other[..32])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
-                other.y.as_bytes_le_mut(
+                other.y.write_bytes_le(
                     (&mut combined_other[32..])
                         .try_into()
                         .expect("Expected 32 bytes"),
@@ -232,23 +232,23 @@ impl ProjectivePoint {
                 let mut combined_other: [u8; 64] = [0; 64];
 
                 // z being ONE means value is not identity
-                self.x.as_bytes_le_mut(
+                self.x.write_bytes_le(
                     (&mut combined_self[..32])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
-                self.y.as_bytes_le_mut(
+                self.y.write_bytes_le(
                     (&mut combined_self[32..])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
 
-                other.x.as_bytes_le_mut(
+                other.x.write_bytes_le(
                     (&mut combined_other[..32])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
-                other.y.as_bytes_le_mut(
+                other.y.write_bytes_le(
                     (&mut combined_other[32..])
                         .try_into()
                         .expect("Expected 32 bytes"),
@@ -346,12 +346,12 @@ impl ProjectivePoint {
                 let mut combined_self: [u8; 64] = [0; 64];
 
                 // z being ONE means value is not identity
-                self.x.as_bytes_le_mut(
+                self.x.write_bytes_le(
                     (&mut combined_self[..32])
                         .try_into()
                         .expect("Expected 32 bytes"),
                 );
-                self.y.as_bytes_le_mut(
+                self.y.write_bytes_le(
                     (&mut combined_self[32..])
                         .try_into()
                         .expect("Expected 32 bytes"),

--- a/k256/src/arithmetic/projective.rs
+++ b/k256/src/arithmetic/projective.rs
@@ -107,15 +107,30 @@ impl ProjectivePoint {
                 let other_x: [u8; 32] = other.x.to_bytes_le().into();
                 let other_y: [u8; 32] = other.y.to_bytes_le().into();
 
-                let (res_x, res_y) = if self_x == other_x && self_y == other_y {
-                    double_u8_le(self_x, self_y)
+                let mut combined: [u8; 64] = [0; 64];
+                let result = if self_x == other_x && self_y == other_y {
+                    combined[..32].copy_from_slice(&self_x);
+                    combined[32..].copy_from_slice(&self_y);
+                    double_u8_le(combined)
                 } else {
-                    add_u8_le(self_x, self_y, other_x, other_y)
+                    combined[..32].copy_from_slice(&self_x);
+                    combined[32..].copy_from_slice(&self_y);
+
+                    let mut combined_other: [u8; 64] = [0; 64];
+                    combined_other[..32].copy_from_slice(&other_x);
+                    combined_other[32..].copy_from_slice(&other_y);
+
+                    add_u8_le(combined, combined_other)
                 };
+                let (res_x, res_y) = result.split_at(32);
 
                 let mut res = *self;
-                res.x = FieldElement::from_bytes_unchecked_le(&res_x);
-                res.y = FieldElement::from_bytes_unchecked_le(&res_y);
+                res.x = FieldElement::from_bytes_unchecked_le(
+                    &res_x.try_into().expect("Expected 32 bytes"),
+                );
+                res.y = FieldElement::from_bytes_unchecked_le(
+                    &res_y.try_into().expect("Expected 32 bytes"),
+                );
                 return res;
             }
 
@@ -209,15 +224,30 @@ impl ProjectivePoint {
                 let other_x: [u8; 32] = other.x.to_bytes_le().into();
                 let other_y: [u8; 32] = other.y.to_bytes_le().into();
 
-                let (res_x, res_y) = if self_x == other_x && self_y == other_y {
-                    double_u8_le(self_x, self_y)
+                let mut combined: [u8; 64] = [0; 64];
+                let result = if self_x == other_x && self_y == other_y {
+                    combined[..32].copy_from_slice(&self_x);
+                    combined[32..].copy_from_slice(&self_y);
+                    double_u8_le(combined)
                 } else {
-                    add_u8_le(self_x, self_y, other_x, other_y)
+                    combined[..32].copy_from_slice(&self_x);
+                    combined[32..].copy_from_slice(&self_y);
+
+                    let mut combined_other: [u8; 64] = [0; 64];
+                    combined_other[..32].copy_from_slice(&other_x);
+                    combined_other[32..].copy_from_slice(&other_y);
+
+                    add_u8_le(combined, combined_other)
                 };
+                let (res_x, res_y) = result.split_at(32);
 
                 let mut res = *self;
-                res.x = FieldElement::from_bytes_unchecked_le(&res_x);
-                res.y = FieldElement::from_bytes_unchecked_le(&res_y);
+                res.x = FieldElement::from_bytes_unchecked_le(
+                    &res_x.try_into().expect("Expected 32 bytes"),
+                );
+                res.y = FieldElement::from_bytes_unchecked_le(
+                    &res_y.try_into().expect("Expected 32 bytes"),
+                );
                 return res;
             }
         }
@@ -295,10 +325,22 @@ impl ProjectivePoint {
                 // z being ONE means value is not identity
                 let self_x: [u8; 32] = self.x.to_bytes_le().into();
                 let self_y: [u8; 32] = self.y.to_bytes_le().into();
-                let (res_x, res_y) = double_u8_le(self_x, self_y);
+
+                let result = {
+                    let mut combined: [u8; 64] = [0; 64];
+                    combined[..32].copy_from_slice(&self_x);
+                    combined[32..].copy_from_slice(&self_y);
+                    double_u8_le(combined)
+                };
+                let (res_x, res_y) = result.split_at(32);
+
                 let mut res = *self;
-                res.x = FieldElement::from_bytes_unchecked_le(&res_x);
-                res.y = FieldElement::from_bytes_unchecked_le(&res_y);
+                res.x = FieldElement::from_bytes_unchecked_le(
+                    &res_x.try_into().expect("Expected 32 bytes"),
+                );
+                res.y = FieldElement::from_bytes_unchecked_le(
+                    &res_y.try_into().expect("Expected 32 bytes"),
+                );
                 return res;
             }
 


### PR DESCRIPTION
This PR adjusts the call into powdr's EC precompiles now that we use the arith-memory machine. The arrays need to be prepared now before the calls, it's some overhead but I think it's fine for this PR. The results using ECDSA are still similar. We can optimize further in the future.